### PR TITLE
Add worker_restart command to staging config

### DIFF
--- a/staging/k8s-askdarcel.yaml
+++ b/staging/k8s-askdarcel.yaml
@@ -137,6 +137,8 @@ spec:
            secretKeyRef:
               name: secret-key
               key: secret-key-base
+       command: ["/bin/sh", "-c"]
+       args: ["cd /home/app/webapp && ./bin/worker_restart.sh"]
      - name: cloudsql-proxy
        image: gcr.io/cloudsql-docker/gce-proxy:1.13
        command: ["/cloud_sql_proxy",


### PR DESCRIPTION
We are introducing background job processing using the `delayed_job` and
`whenever` Ruby gems. During deployment, we need to execute a script to
update our crontab and restart a `delayed_job` worker process.

See also: https://github.com/ShelterTechSF/askdarcel-api/pull/366