### PR TITLE
633 change MOHCD subdomain value to sfserviceguide in staging and prod.

### DIFF
--- a/production/k8s-askdarcel.yaml
+++ b/production/k8s-askdarcel.yaml
@@ -62,7 +62,7 @@ spec:
        - name: SERVER_NAME
          value: "www.askdarcel.org"
        - name: MOHCD_SUBDOMAIN
-         value: help
+         value: "sfserviceguide"
      restartPolicy: Always
 ---
 apiVersion: v1

--- a/production/k8s-askdarcel.yaml
+++ b/production/k8s-askdarcel.yaml
@@ -62,7 +62,9 @@ spec:
        - name: SERVER_NAME
          value: "www.askdarcel.org"
        - name: MOHCD_SUBDOMAIN
-         value: "sfserviceguide"
+         value: help
+       - name: MOHCD_DOMAIN
+         value: sfserviceguide
      restartPolicy: Always
 ---
 apiVersion: v1

--- a/staging/k8s-askdarcel.yaml
+++ b/staging/k8s-askdarcel.yaml
@@ -61,7 +61,9 @@ spec:
        - name: SERVER_NAME
          value: "staging.askdarcel.org"
        - name: MOHCD_SUBDOMAIN
-         value: "sfserviceguide"
+         value: help
+       - name: MOHCD_DOMAIN
+         value: sfserviceguide
      restartPolicy: Always
 ---
 apiVersion: v1

--- a/staging/k8s-askdarcel.yaml
+++ b/staging/k8s-askdarcel.yaml
@@ -61,7 +61,7 @@ spec:
        - name: SERVER_NAME
          value: "staging.askdarcel.org"
        - name: MOHCD_SUBDOMAIN
-         value: help
+         value: "sfserviceguide"
      restartPolicy: Always
 ---
 apiVersion: v1


### PR DESCRIPTION
I can't say that I'm familiar with the gcloud template process; is this the correct way to change the config/env values in our Docker containers? This PR is tied to task 633 which involves displaying a different site logo if a user navigates via sfserviceguide.org: https://github.com/ShelterTechSF/askdarcel-web/issues/633