### PR TITLE
Change Algolia reindexing schedule to be weekly

### DIFF
--- a/production/k8s-askdarcel.yaml
+++ b/production/k8s-askdarcel.yaml
@@ -166,13 +166,13 @@ kind: CronJob
 metadata:
   name: askdarcel-algolia-reindex
 spec:
-  schedule: "0 * * * *"
+  schedule: "0 0 * * 0"
   jobTemplate:
     spec:
       template:
         spec:
           containers:
-          - image: index.docker.io/sheltertechsf/askdarcel-api:1.17.0
+          - image: index.docker.io/sheltertechsf/askdarcel-api:1.18
             name: askdarcel-algolia-reindex
             resources:
               limits:

--- a/staging/k8s-askdarcel.yaml
+++ b/staging/k8s-askdarcel.yaml
@@ -164,7 +164,7 @@ kind: CronJob
 metadata:
   name: askdarcel-algolia-reindex
 spec:
-  schedule: "0 * * * *"
+  schedule: "0 0 * * 0"
   jobTemplate:
     spec:
       template:


### PR DESCRIPTION
The cronjob will run at midnight every week on Sunday (minute 0, hour 0,
day-of-week 0). See description here: https://crontab.guru/#0_0_*_*_0