### PR TITLE
Update Algolia reindex cronjob: concurrency policy and schedule

### DIFF
--- a/production/k8s-askdarcel.yaml
+++ b/production/k8s-askdarcel.yaml
@@ -166,7 +166,7 @@ kind: CronJob
 metadata:
   name: askdarcel-algolia-reindex
 spec:
-  schedule: "0 0 * * 0"
+  schedule: "0 0 * * *"
   concurrencyPolicy: Replace
   jobTemplate:
     spec:

--- a/production/k8s-askdarcel.yaml
+++ b/production/k8s-askdarcel.yaml
@@ -167,6 +167,7 @@ metadata:
   name: askdarcel-algolia-reindex
 spec:
   schedule: "0 0 * * 0"
+  concurrencyPolicy: Replace
   jobTemplate:
     spec:
       template:

--- a/staging/k8s-askdarcel.yaml
+++ b/staging/k8s-askdarcel.yaml
@@ -164,7 +164,7 @@ kind: CronJob
 metadata:
   name: askdarcel-algolia-reindex
 spec:
-  schedule: "0 0 * * 0"
+  schedule: "0 0 * * *"
   concurrencyPolicy: Replace
   jobTemplate:
     spec:

--- a/staging/k8s-askdarcel.yaml
+++ b/staging/k8s-askdarcel.yaml
@@ -128,7 +128,7 @@ spec:
               name: database
               key: database-password
        - name: DATABASE_URL
-         value: "postgres://replaceme:5432/askdarcel"
+         value: "postgres://localhost:5432/askdarcel"
        - name: DATABASE_USERNAME
          valueFrom:
            secretKeyRef:
@@ -193,7 +193,7 @@ spec:
                    name: database
                    key: database-password
             - name: DATABASE_URL
-              value: "postgres://replaceme:5432/askdarcel"
+              value: "postgres://localhost:5432/askdarcel"
             - name: DATABASE_USERNAME
               valueFrom:
                 secretKeyRef:

--- a/staging/k8s-askdarcel.yaml
+++ b/staging/k8s-askdarcel.yaml
@@ -128,7 +128,7 @@ spec:
               name: database
               key: database-password
        - name: DATABASE_URL
-         value: "postgres://localhost:5432/askdarcel"
+         value: "postgres://replaceme:5432/askdarcel"
        - name: DATABASE_USERNAME
          valueFrom:
            secretKeyRef:
@@ -144,19 +144,6 @@ spec:
            secretKeyRef:
               name: secret-key
               key: secret-key-base
-     - name: cloudsql-proxy
-       image: gcr.io/cloudsql-docker/gce-proxy:1.13
-       command: ["/cloud_sql_proxy",
-       "-instances=askdarcel-staging-208823:us-central1:askdarcel-staging-db=tcp:5432",
-        "-credential_file=/secrets/cloudsql/credentials.json"]
-       volumeMounts:
-         - name: cloudsql-instance-credentials
-           mountPath: /secrets/cloudsql
-           readOnly: true
-     volumes:
-       - name: cloudsql-instance-credentials
-         secret:
-           secretName: cloudsql-instance-credentials
      restartPolicy: Always
 ---
 apiVersion: batch/v1beta1
@@ -181,7 +168,7 @@ spec:
             args:
             - /bin/sh
             - -c
-            - cd /home/app/webapp && bundle exec rake algolia:reindex
+            - cd /home/app/webapp && bundle exec rake algolia:reindex && exit
             env:
             - name: ALGOLIA_API_KEY
               valueFrom:
@@ -206,7 +193,7 @@ spec:
                    name: database
                    key: database-password
             - name: DATABASE_URL
-              value: "postgres://localhost:5432/askdarcel"
+              value: "postgres://replaceme:5432/askdarcel"
             - name: DATABASE_USERNAME
               valueFrom:
                 secretKeyRef:
@@ -222,19 +209,6 @@ spec:
                 secretKeyRef:
                    name: secret-key
                    key: secret-key-base
-          - name: cloudsql-proxy
-            image: gcr.io/cloudsql-docker/gce-proxy:1.13
-            command: ["/cloud_sql_proxy",
-            "-instances=askdarcel-staging-208823:us-central1:askdarcel-staging-db=tcp:5432",
-             "-credential_file=/secrets/cloudsql/credentials.json"]
-            volumeMounts:
-              - name: cloudsql-instance-credentials
-                mountPath: /secrets/cloudsql
-                readOnly: true
-          volumes:
-            - name: cloudsql-instance-credentials
-              secret:
-                secretName: cloudsql-instance-credentials
           restartPolicy: OnFailure
 ---
 apiVersion: v1

--- a/staging/k8s-askdarcel.yaml
+++ b/staging/k8s-askdarcel.yaml
@@ -165,6 +165,7 @@ metadata:
   name: askdarcel-algolia-reindex
 spec:
   schedule: "0 0 * * 0"
+  concurrencyPolicy: Replace
   jobTemplate:
     spec:
       template:


### PR DESCRIPTION
Update concurrency policy such that there is only ever one Algolia reindex cronjob running at a time.

Update schedule to execute an Algolia reindex cronjob daily.